### PR TITLE
MLB-14 Upgraded GCP Terraform Module to use Terraform Service instead of Google Cloud Controller.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ module "red5pro_single" {
   # Single Red5 Pro server Instance configuration
   single_server_instance_type                   = "n2-standard-2"                            # Instance type for Red5 Pro server
   single_server_boot_disk_type                  = "pd-ssd"                                   # Boot disk type for Single server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
+  single_server_network_tag                     = "example-single-server-instance"           # Specify the Network Tag for Red5 Single Server instance to be used by the Virtual Network firewall
 
   # Red5Pro server configuration
   red5pro_license_key                           = "1111-2222-3333-4444"                      # Red5 Pro license key (https://account.red5.net/login)
@@ -194,11 +195,12 @@ module "red5pro_cluster" {
   # Terraform Service configuration
   terraform_service_instance_create = false                                                # true - Create a dedicate terraform service instance, false - install terraform service locally on the stream manager
   terraform_service_api_key         = "examplekey"                                         # Terraform service api key
+  terraform_service_network_tag     = "example-terraform-service-instance"                 # Specify the Network Tag for Terraform Service instance to be used by the Virtual Network firewall
   terraform_service_parallelism     = "20"                                                 # Terraform service parallelism
   terraform_service_boot_disk_type  = "pd-ssd"                                             # Boot disk type for Terraform server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   terraform_service_instance_type   = "n2-standard-2"                                      # Terraform service Instance type
   gcp_node_boot_disk_type           = "pd-ssd"                                             # Boot disk type for Nodes in Terraform Service. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
-  gcp_node_network_tag              = "null"                                               # Specify Node Network tag which will be used by Terraform service while creating Node. Default value is null
+  gcp_node_network_tag              = "example-node-instance"                              # Specify new/existing Node Network tag which will be used by Terraform service while creating Node and it will be utilized by Firewall in GCP. Default value is null
 
   # Red5 Pro server Instance configuration
   create_new_reserved_ip_for_stream_manager  = true                                        # True - Create a new reserved IP for stream manager, False - Use already created reserved IP address
@@ -207,6 +209,7 @@ module "red5pro_cluster" {
   stream_manager_api_key                     = "examplekey"                                # Stream Manager api key
   stream_manager_server_boot_disk_type       = "pd-ssd"                                    # Boot disk type for Stream Manager server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   stream_manager_server_disk_size            = 50                                          # Stream Manager server boot size in GB
+  stream_manager_network_tag                 = "example-sm-instance"                       # Specify the Network Tag for Stream Manager to be used by the Virtual Network firewall
 
   # Red5 Pro cluster Origin node image configuration
   origin_image_create                                      = true                          # Default: true for Autoscaling and Cluster, true - create new Origin node image, false - not create new Origin node image
@@ -322,14 +325,16 @@ module "red5pro_autoscaling" {
   stream_manager_api_key               = "examplekey"                                      # Stream Manager api key
   stream_manager_server_boot_disk_type = "pd-ssd"                                          # Boot disk type for Stream Manager server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   stream_manager_server_disk_size      = 10                                                # Stream Manager server boot size in GB
+  stream_manager_network_tag           = "example-sm-instance"                             # Specify the Network Tag for Stream Manager to be used by the Virtual Network firewall
 
   # Terraform Service configuration
   terraform_service_api_key         = "examplekey"                                         # Terraform service api key
   terraform_service_parallelism     = "20"                                                 # Terraform service parallelism
+  terraform_service_network_tag     = "example-terraform-service-instance"                 # Specify the Network Tag for Terraform Service instance to be used by the Virtual Network firewall
   terraform_service_boot_disk_type  = "pd-ssd"                                             # Boot disk type for Terraform server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   terraform_service_instance_type   = "n2-standard-2"                                      # Terraform service Instance type
   gcp_node_boot_disk_type           = "pd-ssd"                                             # Boot disk type for Nodes in Terraform Service. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
-  gcp_node_network_tag              = "null"                                               # Specify Node Network tag which will be used by Terraform service while creating Node. Default value is null
+  gcp_node_network_tag              = "example-node-instance"                              # Specify new/existing Node Network tag which will be used by Terraform service while creating Node and it will be utilized by Firewall in GCP. Default value is null
 
   # Load Balancer Configuration
   create_new_global_reserved_ip_for_lb = true                                              # True - Create a new reserved IP for Load Balancer, False - Use existing reserved IP for Load Balancer

--- a/examples/autoscale/README.md
+++ b/examples/autoscale/README.md
@@ -8,6 +8,7 @@
 * **SSL Certificates** - This Terraform Module can create or use existing SSL certificate for Load Balancer
 * **MySQL Database** - This Terraform Module create a MySQL databse server in Google Cloud.
 * **Stream Manager** - Instance will be created automatically for Stream Manager
+* **Terraform Server** - This will create a dedicated instance for Terrform Service
 * **Origin Node Image** - To create Google Cloud(Gcloud) custom image for Orgin Node type for Stream Manager node group
 * **Edge Node Image** - To create Google Cloud(Gcloud) custom image for Edge Node type for Stream Manager node group (optional)
 * **Transcoder Node Image** - To create Google Cloud(Gcloud) custom image for Transcoder Node type for Stream Manager node group (optional)
@@ -17,7 +18,8 @@ Example:
 
 ```bash
 cp ~/Downloads/red5pro-server-0.0.0.b0-release.zip ./
-cp ~/Downloads/google-cloud-controller-0.0.0.jar ./
+cp ~/Downloads/terraform-cloud-controller-0.0.0.jar ./
+cp ~/Downloads/terraform-service-0.0.0.zip ./
 ```
 
 ## Usage
@@ -81,4 +83,5 @@ No inputs.
 | <a name="output_stream_manager_http_url"></a> [stream\_manager\_http\_url](#output\_stream\_manager\_http\_url) | Stream Manager HTTP URL |
 | <a name="output_stream_manager_https_url"></a> [stream\_manager\_https\_url](#output\_stream\_manager\_https\_url) | Stream Manager HTTPS URL |
 | <a name="output_stream_manager_ip"></a> [stream\_manager\_ip](#output\_stream\_manager\_ip) | Stream Manager IP |
+| <a name="output_terraform_service_ip"></a> [terraform\_service\_ip](#output\_terraform\_service\_ip) | Terraform Service Host |
 | <a name="output_vpc_netwrok_name"></a> [vpc\_netwrok\_name](#output\_vpc\_netwrok\_name) | VPC Network name used in Google Cloud |

--- a/examples/autoscale/main.tf
+++ b/examples/autoscale/main.tf
@@ -44,14 +44,16 @@ module "red5pro_autoscaling" {
   stream_manager_api_key               = "examplekey"                                      # Stream Manager api key
   stream_manager_server_boot_disk_type = "pd-ssd"                                          # Boot disk type for Stream Manager server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   stream_manager_server_disk_size      = 10                                                # Stream Manager server boot size in GB
+  stream_manager_network_tag           = "example-sm-instance"                             # Specify the Network Tag for Stream Manager to be used by the Virtual Network firewall
 
   # Terraform Service configuration
   terraform_service_api_key         = "examplekey"                                         # Terraform service api key
   terraform_service_parallelism     = "20"                                                 # Terraform service parallelism
+  terraform_service_network_tag     = "example-terraform-service-instance"                 # Specify the Network Tag for Terraform Service instance to be used by the Virtual Network firewall
   terraform_service_boot_disk_type  = "pd-ssd"                                             # Boot disk type for Terraform server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   terraform_service_instance_type   = "n2-standard-2"                                      # Terraform service Instance type
   gcp_node_boot_disk_type           = "pd-ssd"                                             # Boot disk type for Nodes in Terraform Service. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
-  gcp_node_network_tag              = "null"                                               # Specify Node Network tag which will be used by Terraform service while creating Node. Default value is null
+  gcp_node_network_tag              = "example-node-instance"                              # Specify new/existing Node Network tag which will be used by Terraform service while creating Node and it will be utilized by Firewall in GCP. Default value is null
 
   # Load Balancer Configuration
   create_new_global_reserved_ip_for_lb = true                                              # True - Create a new reserved IP for Load Balancer, False - Use existing reserved IP for Load Balancer

--- a/examples/autoscale/main.tf
+++ b/examples/autoscale/main.tf
@@ -14,7 +14,8 @@ module "red5pro_autoscaling" {
   type                             = "autoscaling"                                         # Deployment type: single, cluster, autoscaling
   name                             = "red5pro-autoscaling"                                 # Name to be used on all the resources as identifier
   path_to_red5pro_build            = "./red5pro-server-0.0.0.b0-release.zip"               # Absolute path or relative path to Red5 Pro server ZIP file
-  path_to_google_cloud_controller  = "./google-cloud-controller-0.0.0.jar"                 # Absolute path or relative path to google cloud controller jar file
+  path_to_terraform_cloud_controller  = "./terraform-cloud-controller-0.0.0.jar"           # Absolute path or relative path to terraform cloud controller jar file
+  path_to_terraform_service_build     = "./terraform-service-0.0.0.zip"                    # Absolute path or relative path to terraform service ZIP file
 
   # SSH key configuration
   create_new_ssh_keys              = true                                                  # true - create new SSH key, false - use existing SSH key
@@ -44,7 +45,15 @@ module "red5pro_autoscaling" {
   stream_manager_server_boot_disk_type = "pd-ssd"                                          # Boot disk type for Stream Manager server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   stream_manager_server_disk_size      = 10                                                # Stream Manager server boot size in GB
 
-# Load Balancer Configuration
+  # Terraform Service configuration
+  terraform_service_api_key         = "examplekey"                                         # Terraform service api key
+  terraform_service_parallelism     = "20"                                                 # Terraform service parallelism
+  terraform_service_boot_disk_type  = "pd-ssd"                                             # Boot disk type for Terraform server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
+  terraform_service_instance_type   = "n2-standard-2"                                      # Terraform service Instance type
+  gcp_node_boot_disk_type           = "pd-ssd"                                             # Boot disk type for Nodes in Terraform Service. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
+  gcp_node_network_tag              = "null"                                               # Specify Node Network tag which will be used by Terraform service while creating Node. Default value is null
+
+  # Load Balancer Configuration
   create_new_global_reserved_ip_for_lb = true                                              # True - Create a new reserved IP for Load Balancer, False - Use existing reserved IP for Load Balancer
   existing_global_lb_reserved_ip_name  = ""                                                # If `create_new_global_reserved_ip_for_lb` - False, Use the already created Load balancer IP address name
   lb_http_port_required                = "5080"                                            # The required HTTP port used by Load Balancer other than HTTPS, Default 5080

--- a/examples/autoscale/output.tf
+++ b/examples/autoscale/output.tf
@@ -73,3 +73,8 @@ output "load_balancer_url" {
   description = "Load Balancer HTTPS URL"
   value       = module.red5pro_autoscaling.load_balancer_url
 }
+
+output "terraform_service_ip" {
+  description = "Terraform Service Host"
+  value       = module.red5pro_autoscaling.terraform_service_ip
+}

--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -7,6 +7,7 @@
 * **SSL Certificates** - User can install Let's encrypt SSL certificates or use Red5Pro server without SSL certificate (HTTP only).
 * **MySQL Database** - Users have flexibility to create a MySQL databse server in Google Cloud or install it locally on the Stream Manager
 * **Stream Manager** - Instance will be created automatically for Stream Manager
+* **Terraform Server** - Uesrs can choose to create a dedicated instance for Terraform Server or install it locally on the Stream Manager
 * **Origin Node Image** - To create Google Cloud(Gcloud) custom image for Orgin Node type for Stream Manager node group
 * **Edge Node Image** - To create Google Cloud(Gcloud) custom image for Edge Node type for Stream Manager node group (optional)
 * **Transcoder Node Image** - To create Google Cloud(Gcloud) custom image for Transcoder Node type for Stream Manager node group (optional)
@@ -16,7 +17,8 @@ Example:
 
 ```bash
 cp ~/Downloads/red5pro-server-0.0.0.b0-release.zip ./
-cp ~/Downloads/google-cloud-controller-0.0.0.jar ./
+cp ~/Downloads/terraform-cloud-controller-0.0.0.jar ./
+cp ~/Downloads/terraform-service-0.0.0.zip ./
 ```
 
 ## Usage
@@ -79,4 +81,5 @@ No inputs.
 | <a name="output_stream_manager_http_url"></a> [stream\_manager\_http\_url](#output\_stream\_manager\_http\_url) | Stream Manager HTTP URL |
 | <a name="output_stream_manager_https_url"></a> [stream\_manager\_https\_url](#output\_stream\_manager\_https\_url) | Stream Manager HTTPS URL |
 | <a name="output_stream_manager_ip"></a> [stream\_manager\_ip](#output\_stream\_manager\_ip) | Stream Manager IP |
+| <a name="output_terraform_service_ip"></a> [terraform\_service\_ip](#output\_terraform\_service\_ip) | Terraform Service Host |
 | <a name="output_vpc_netwrok_name"></a> [vpc\_netwrok\_name](#output\_vpc\_netwrok\_name) | VPC Network name used in Google Cloud |

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -49,11 +49,12 @@ module "red5pro_cluster" {
   # Terraform Service configuration
   terraform_service_instance_create = false                                                # true - Create a dedicate terraform service instance, false - install terraform service locally on the stream manager
   terraform_service_api_key         = "examplekey"                                         # Terraform service api key
+  terraform_service_network_tag     = "example-terraform-service-instance"                 # Specify the Network Tag for Terraform Service instance to be used by the Virtual Network firewall
   terraform_service_parallelism     = "20"                                                 # Terraform service parallelism
   terraform_service_boot_disk_type  = "pd-ssd"                                             # Boot disk type for Terraform server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   terraform_service_instance_type   = "n2-standard-2"                                      # Terraform service Instance type
   gcp_node_boot_disk_type           = "pd-ssd"                                             # Boot disk type for Nodes in Terraform Service. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
-  gcp_node_network_tag              = "null"                                               # Specify Node Network tag which will be used by Terraform service while creating Node. Default value is null
+  gcp_node_network_tag              = "example-node-instance"                              # Specify new/existing Node Network tag which will be used by Terraform service while creating Node and it will be utilized by Firewall in GCP. Default value is null
 
   # Red5 Pro server Instance configuration
   create_new_reserved_ip_for_stream_manager  = true                                        # True - Create a new reserved IP for stream manager, False - Use already created reserved IP address
@@ -62,6 +63,7 @@ module "red5pro_cluster" {
   stream_manager_api_key                     = "examplekey"                                # Stream Manager api key
   stream_manager_server_boot_disk_type       = "pd-ssd"                                    # Boot disk type for Stream Manager server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
   stream_manager_server_disk_size            = 50                                          # Stream Manager server boot size in GB
+  stream_manager_network_tag                 = "example-sm-instance"                       # Specify the Network Tag for Stream Manager to be used by the Virtual Network firewall
 
   # Red5 Pro cluster Origin node image configuration
   origin_image_create                                      = true                          # Default: true for Autoscaling and Cluster, true - create new Origin node image, false - not create new Origin node image

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -14,8 +14,9 @@ module "red5pro_cluster" {
   type                             = "cluster"                                             # Deployment type: single, cluster, autoscaling
   name                             = "red5pro-cluster"                                     # Name to be used on all the resources as identifier
   path_to_red5pro_build            = "./red5pro-server-0.0.0.b0-release.zip"               # Absolute path or relative path to Red5 Pro server ZIP file
-  path_to_google_cloud_controller  = "./google-cloud-controller-0.0.0.jar"                 # Absolute path or relative path to google cloud controller jar file
- 
+  path_to_terraform_cloud_controller  = "./terraform-cloud-controller-0.0.0.jar"           # Absolute path or relative path to terraform cloud controller jar file
+  path_to_terraform_service_build     = "./terraform-service-0.0.0.zip"                    # Absolute path or relative path to terraform service ZIP file
+
   # SSH key configuration
   create_new_ssh_keys              = true                                                  # true - create new SSH key, false - use existing SSH key
   new_ssh_key_name                 = "example-ssh-key"                                     # if `create_new_ssh_keys` = true, Name for new SSH key
@@ -45,6 +46,15 @@ module "red5pro_cluster" {
   https_letsencrypt_certificate_email        = "email@example.com"                         # Email for Let's Encrypt SSL certificate
   https_letsencrypt_certificate_password     = "examplepass"                               # Password for Let's Encrypt SSL certificate
   
+  # Terraform Service configuration
+  terraform_service_instance_create = false                                                # true - Create a dedicate terraform service instance, false - install terraform service locally on the stream manager
+  terraform_service_api_key         = "examplekey"                                         # Terraform service api key
+  terraform_service_parallelism     = "20"                                                 # Terraform service parallelism
+  terraform_service_boot_disk_type  = "pd-ssd"                                             # Boot disk type for Terraform server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
+  terraform_service_instance_type   = "n2-standard-2"                                      # Terraform service Instance type
+  gcp_node_boot_disk_type           = "pd-ssd"                                             # Boot disk type for Nodes in Terraform Service. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
+  gcp_node_network_tag              = "null"                                               # Specify Node Network tag which will be used by Terraform service while creating Node. Default value is null
+
   # Red5 Pro server Instance configuration
   create_new_reserved_ip_for_stream_manager  = true                                        # True - Create a new reserved IP for stream manager, False - Use already created reserved IP address
   existing_sm_reserved_ip_name               = "example-reserved-ip"                       # If `create_new_reserved_ip_for_stream_manager` = false then specify the name of already create reserved IP for stream manager in the provided region.

--- a/examples/cluster/output.tf
+++ b/examples/cluster/output.tf
@@ -68,3 +68,8 @@ output "stream_manager_https_url" {
   description = "Stream Manager HTTPS URL"
   value       = module.red5pro_cluster.stream_manager_https_url
 }
+
+output "terraform_service_ip" {
+  description = "Terraform Service Host"
+  value       = module.red5pro_cluster.terraform_service_ip
+}

--- a/examples/single/main.tf
+++ b/examples/single/main.tf
@@ -35,6 +35,7 @@ module "red5pro_single" {
   # Single Red5 Pro server Instance configuration
   single_server_instance_type                   = "n2-standard-2"                            # Instance type for Red5 Pro server
   single_server_boot_disk_type                  = "pd-ssd"                                   # Boot disk type for Single server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`
+  single_server_network_tag                     = "example-single-server-instance"           # Specify the Network Tag for Red5 Single Server instance to be used by the Virtual Network firewall
 
   # Red5Pro server configuration
   red5pro_license_key                           = "1111-2222-3333-4444"                      # Red5 Pro license key (https://account.red5.net/login)

--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,7 @@ resource "google_compute_firewall" "red5_single_firewall" {
 
   source_ranges = ["0.0.0.0/0"]
   project       = local.google_cloud_project
+  target_tags   = tolist([var.single_server_network_tag])
 }
 
 resource "google_compute_firewall" "red5_single_ssh_firewall" {
@@ -197,6 +198,7 @@ resource "google_compute_instance" "red5_single_server" {
       private_key = "${local.private_ssh_key}"
     }
   }
+  tags            = tolist([var.single_server_network_tag])
 }
 
 ################################################################################
@@ -220,6 +222,7 @@ resource "google_compute_firewall" "red5_stream_manager_firewall" {
   }
   source_ranges = ["0.0.0.0/0"]
   project       = local.google_cloud_project
+  target_tags   = tolist([var.stream_manager_network_tag])
 }
 
 # Reserved IP address for Stream Manager
@@ -350,6 +353,7 @@ resource "google_compute_instance" "red5_stream_manager_server" {
   service_account {
     scopes = [ "cloud-platform" ]
   }
+  tags             = tolist([var.stream_manager_network_tag])
   lifecycle {
     ignore_changes = all
     precondition {
@@ -439,6 +443,7 @@ resource "google_compute_instance" "red5pro_terraform_service" {
   service_account {
     scopes = [ "cloud-platform" ]
   }
+  tags     = tolist([var.terraform_service_network_tag])
 }
 
 resource "google_compute_firewall" "red5_terraform_service_firewall" {
@@ -457,6 +462,7 @@ resource "google_compute_firewall" "red5_terraform_service_firewall" {
 
   source_ranges = ["0.0.0.0/0"]
   project       = local.google_cloud_project
+  target_tags   = tolist([var.terraform_service_network_tag])
 }
 
 ################################################################################
@@ -552,7 +558,7 @@ resource "google_compute_instance_template" "stream_manager_template" {
   count               = local.autoscaling ? 1 : 0
   name                = "${var.name}-stream-manager"
   machine_type        = var.stream_manager_server_instance_type
-  tags                = ["${var.name}-sm-template"]
+  tags                = tolist([var.stream_manager_network_tag])
   project             = local.google_cloud_project
   metadata = {
     ssh-keys          = "ubuntu:${local.public_ssh_key}"
@@ -713,6 +719,7 @@ resource "google_compute_firewall" "red5_node_firewall" {
   }
   source_ranges = ["0.0.0.0/0"]
   project       = local.google_cloud_project
+  target_tags   = var.gcp_node_network_tag != "null" ? tolist([var.gcp_node_network_tag]) : []
 }
 
 # Red5 Pro Origin server instance
@@ -801,6 +808,7 @@ resource "google_compute_instance" "red5_origin_server" {
   lifecycle {
     ignore_changes = all
   }
+  tags       = tolist([var.gcp_node_network_tag])
   depends_on = [ google_compute_instance.red5_stream_manager_server ]
 }
 
@@ -885,6 +893,7 @@ resource "google_compute_instance" "red5_edge_server" {
   lifecycle {
     ignore_changes = all
   }
+  tags             = tolist([var.gcp_node_network_tag])
 }
 
 # Red5 Pro Transcoder server instance
@@ -973,6 +982,7 @@ resource "google_compute_instance" "red5_transcoder_server" {
   lifecycle {
     ignore_changes = all
   }
+  tags             = tolist([var.gcp_node_network_tag])
 }
 
 # Red5 Pro Relay server instance
@@ -1056,6 +1066,7 @@ resource "google_compute_instance" "red5_relay_server" {
   lifecycle {
     ignore_changes = all
   }
+  tags             = tolist([var.gcp_node_network_tag])
 }
 
 #################################################################################################

--- a/output.tf
+++ b/output.tf
@@ -91,3 +91,8 @@ output "load_balancer_url" {
   description = "Load Balancer HTTPS URL"
   value       = local.autoscaling && var.create_lb_with_ssl ? "https://${local.lb_ip_address}:443" : local.autoscaling ? "http://${local.lb_ip_address}:${local.sm_port}" : null
 }
+
+output "terraform_service_ip" {
+  description = "Terraform Service Host"
+  value       = local.terraform_service_ip
+}

--- a/red5pro-installer/r5p_config_stream_manager.sh
+++ b/red5pro-installer/r5p_config_stream_manager.sh
@@ -3,9 +3,8 @@
 # Red5 Pro Stream Manager Configuration Script
 ############################################################################################################
 
-# GOGOLE_PROJECT_ID
-# GOOGLE_DEFAULT_ZONE_ID
-# GOOGLE_VPC_NETWORK_NAME
+# TERRA_HOST
+# TERRA_API_KEY
 # DB_HOST
 # DB_PORT
 # DB_USER
@@ -37,16 +36,12 @@ log() {
 config_sm_properties_gcp(){
     log_i "Start configuration Stream Manager properties for Google Cloud"
     
-    if [ -z "$GOGOLE_PROJECT_ID" ]; then
-        log_w "Variable GOGOLE_PROJECT_ID is empty."
+    if [ -z "$TERRA_HOST" ]; then
+        log_w "Variable TERRA_HOST is empty."
         var_error=1
     fi
-    if [ -z "$GOOGLE_DEFAULT_ZONE_ID" ]; then
-        log_w "Variable GOOGLE_DEFAULT_ZONE_ID is empty."
-        var_error=1
-    fi
-    if [ -z "$GOOGLE_VPC_NETWORK_NAME" ]; then
-        log_w "Variable GOOGLE_VPC_NETWORK_NAME is empty."
+    if [ -z "$TERRA_API_KEY" ]; then
+        log_w "Variable TERRA_API_KEY is empty."
         var_error=1
     fi
     if [[ "$var_error" == "1" ]]; then
@@ -54,22 +49,22 @@ config_sm_properties_gcp(){
         exit 1
     fi
     
-    local google_project_id='#compute.project=.*'
-    local google_project_id_new="compute.project=${GOGOLE_PROJECT_ID}"
+    local terra_region_pattern='#terra.regionNames=.*'
+    local terra_region_new="terra.regionNames=us-west1, us-west2, us-west3, us-west4, us-south1, us-east5, us-east4, us-east1, us-central1, southamerica-west1, southamerica-east1, northamerica-northeast1, me-west1, me-central2, me-central1, europe-west9, europe-west8, europe-west6, europe-west4, europe-west3, europe-west2, europe-southwest1, europe-north1, europe-central2, asia-south1, asia-northeast3, asia-northeast2, asia-northeast1, asia-east2, asia-east1, africa-south1"
     
-    local google_default_zone_id='#compute.defaultzone=.*'
-    local google_default_zone_id_new="compute.defaultzone=${GOOGLE_DEFAULT_ZONE_ID}"
+    local terra_instance_name_pattern='#terra.instanceName=.*'
+    local terra_instance_name_new="terra.instanceName=gcp_instance"
     
-    local google_vpc_network_name='#compute.network=.*'
-    local google_vpc_network_name_new="compute.network=${GOOGLE_VPC_NETWORK_NAME}"
-
-    local google_default_disk="#compute.defaultdisk=.*"
-    local google_default_disk_new="compute.defaultdisk=pd-standard"
-
-    local google_timeout="#compute.operationTimeoutMilliseconds=.*"
-    local google_timeout_new="compute.operationTimeoutMilliseconds=200000"
-
-    sed -i -e "s|$google_project_id|$google_project_id_new|" -e "s|$google_default_zone_id|$google_default_zone_id_new|" -e "s|$google_vpc_network_name|$google_vpc_network_name_new|" -e "s|$google_default_disk|$google_default_disk_new|" -e "s|$google_timeout|$google_timeout_new|" "$RED5_HOME/webapps/streammanager/WEB-INF/red5-web.properties"
+    local terra_host_pattern='#terra.host=.*'
+    local terra_host_new="terra.host=${TERRA_HOST}"
+    
+    local terra_port_pattern='#terra.port=.*'
+    local terra_port_new="terra.port=8083"
+    
+    local terra_token_pattern='#terra.token=.*'
+    local terra_token_new="terra.token=${TERRA_API_KEY}"
+    
+    sed -i -e "s|$terra_region_pattern|$terra_region_new|" -e "s|$terra_instance_name_pattern|$terra_instance_name_new|" -e "s|$terra_host_pattern|$terra_host_new|" -e "s|$terra_port_pattern|$terra_port_new|" -e "s|$terra_token_pattern|$terra_token_new|" "$RED5_HOME/webapps/streammanager/WEB-INF/red5-web.properties"
         
 }
 
@@ -198,21 +193,21 @@ install_sm(){
 }
 
 config_sm_applicationContext(){
-    log_i "Set google-cloud-controller in $RED5_HOME/webapps/streammanager/WEB-INF/applicationContext.xml"
+    log_i "Set terraform-cloud-controller in $RED5_HOME/webapps/streammanager/WEB-INF/applicationContext.xml"
     
     local def_controller='<!-- Default CONTROLLER -->'
     local def_controller_new='<!-- Disabled: Default CONTROLLER --> <!--'
 
-    local google_controller='<!-- AWS CONTROLLER -->'
-    local google_controller_new='--> <!-- AWS CONTROLLER -->'
+    local terra_controller='<!-- AWS CONTROLLER -->'
+    local terra_controller_new='--> <!-- AWS CONTROLLER -->'
 
-    local google_controller_in='<!-- <bean id="apiBridge" class="com.red5pro.services.cloud.google.component.ComputeInstanceController"'
-    local google_controller_in_new='<bean id="apiBridge" class="com.red5pro.services.cloud.google.component.ComputeInstanceController"'
+    local terra_controller_in='<!-- <bean id="apiBridge" class="com.red5pro.services.terraform.component.TerraformCloudController"'
+    local terra_controller_in_new='<bean id="apiBridge" class="com.red5pro.services.terraform.component.TerraformCloudController"'
 
-    local google_controller_out='value="${compute.network}"/> </bean> -->'
-    local google_controller_out_new='value="${compute.network}"/> </bean>'
+    local terra_controller_out='/> <property name="terraToken" value="${terra.token}"/> </bean> -->'
+    local terra_controller_out_new='/> <property name="terraToken" value="${terra.token}"/> </bean>'
 
-    sed -i -e "s|$def_controller|$def_controller_new|" -e "s|$google_controller|$google_controller_new|" -e "s|$google_controller_in|$google_controller_in_new|" -e "s|$google_controller_out|$google_controller_out_new|" "$RED5_HOME/webapps/streammanager/WEB-INF/applicationContext.xml"
+    sed -i -e "s|$def_controller|$def_controller_new|" -e "s|$terra_controller|$terra_controller_new|" -e "s|$terra_controller_in|$terra_controller_in_new|" -e "s|$terra_controller_out|$terra_controller_out_new|" "$RED5_HOME/webapps/streammanager/WEB-INF/applicationContext.xml"
 }
 
 config_sm_cors(){

--- a/red5pro-installer/r5p_install_terraform_svc.sh
+++ b/red5pro-installer/r5p_install_terraform_svc.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+##############################################################################################################
+# Install and configure Terraform service for GCP
+# Before start this script you need copy terraform-service-build.zip into the same folder with this script!!!
+##############################################################################################################
+
+# TERRA_API_KEY="abc123"
+# GCP_PROJECT_ID=""
+# GCP_VPC_NAME=""
+# GCP_NODE_NETWORK_TAG=""
+# TERRA_PARALLELISM="20"
+# DO_API_TOKEN=""
+# SSH_KEY_NAME=""
+# DB_HOST="test.com"
+# DB_PORT="25060"
+# DB_USER="smuser"
+# DB_PASSWORD="abc123"
+
+TERRA_FOLDER="/usr/local/red5service"
+CURRENT_DIRECTORY=$(pwd)
+PACKAGES=(default-jre unzip ntp apt-transport-https ca-certificates gnupg curl)
+
+log_i() {
+    log
+    printf "\033[0;32m [INFO]  --- %s \033[0m\n" "${@}"
+}
+log_w() {
+    log
+    printf "\033[0;35m [WARN] --- %s \033[0m\n" "${@}"
+}
+log_e() {
+    log
+    printf "\033[0;31m [ERROR]  --- %s \033[0m\n" "${@}"
+}
+log() {
+    echo -n "[$(date '+%Y-%m-%d %H:%M:%S')]"
+}
+
+check_terraform_variables(){
+    log_i "Check TERRAFORM variables..."
+    
+    if [ -z "$TERRA_API_KEY" ]; then
+        log_w "Variable TERRA_API_KEY is empty."
+        var_error=1
+    fi
+    if [ -z "$TERRA_PARALLELISM" ]; then
+        log_w "Variable TERRA_PARALLELISM is empty."
+        var_error=1
+    fi
+    if [ -z "$GCP_PROJECT_ID" ]; then
+        log_w "Variable GCP_PROJECT_ID is empty."
+        var_error=1
+    fi
+    if [ -z "$GCP_VPC_NAME" ]; then
+        log_w "Variable GCP_VPC_NAME is empty."
+        var_error=1
+    fi
+    if [ -z "$GCP_NODE_NETWORK_TAG" ]; then
+        log_w "Variable GCP_NODE_NETWORK_TAG is empty."
+        var_error=1
+    fi
+    if [ -z "$GCP_NODE_DISK_TYPE" ]; then
+        log_w "Variable GCP_NODE_DISK_TYPE is empty."
+        var_error=1
+    fi
+    if [ -z "$DB_HOST" ]; then
+        log_w "Variable DB_HOST is empty."
+        var_error=1
+    fi
+    if [ -z "$DB_PORT" ]; then
+        log_w "Variable DB_PORT is empty."
+        var_error=1
+    fi
+    if [ -z "$DB_USER" ]; then
+        log_w "Variable DB_PORT is empty."
+        var_error=1
+    fi
+    if [ -z "$DB_PASSWORD" ]; then
+        log_w "Variable DB_PASSWORD is empty."
+        var_error=1
+    fi
+    if [[ "$var_error" == "1" ]]; then
+        log_e "One or more variables are empty. EXIT!"
+        exit 1
+    fi
+}
+
+install_pkg(){
+    
+    for i in {1..5};
+    do
+        
+        local install_issuse=0;
+        apt-get -y update --fix-missing &> /dev/null
+        
+        for index in ${!PACKAGES[*]}
+        do
+            log_i "Install utility ${PACKAGES[$index]}"
+            apt-get install -y ${PACKAGES[$index]} &> /dev/null
+        done
+        
+        for index in ${!PACKAGES[*]}
+        do
+            PKG_OK=$(dpkg-query -W --showformat='${Status}\n' ${PACKAGES[$index]}|grep "install ok installed")
+            if [ -z "$PKG_OK" ]; then
+                log_i "${PACKAGES[$index]} utility didn't install, didn't find MIRROR !!! "
+                install_issuse=$(($install_issuse+1));
+            else
+                log_i "${PACKAGES[$index]} utility installed"
+            fi
+        done
+        
+        if [ $install_issuse -eq 0 ]; then
+            break
+        fi
+        if [ $i -ge 5 ]; then
+            log_e "Something wrong with packages installation!!! Exit."
+            exit 1
+        fi
+        sleep 20
+    done
+}
+
+install_terraform_service(){
+    log_i "Install TERRAFORM SERVICE"
+    
+    TERRA_RCHIVE=$(ls $CURRENT_DIRECTORY/terraform-service*.zip | xargs -n 1 basename);
+    
+    if [ ! -f "$TERRA_RCHIVE" ]; then
+        log_e "Terraform service archive was not found: $TERRA_RCHIVE. EXIT..."
+        exit 1
+    fi
+    
+    unzip -q "$CURRENT_DIRECTORY/$TERRA_RCHIVE" -d /usr/local/
+    
+    rm $TERRA_FOLDER/*_azure*.tf
+    rm $TERRA_FOLDER/*_linode*.tf
+    rm $TERRA_FOLDER/*_vsphere*.tf
+    rm $TERRA_FOLDER/*_do*.tf
+    rm -rf $TERRA_FOLDER/cloud_controller_oracle/ $TERRA_FOLDER/cloud_controller_private/
+
+    cp $TERRA_FOLDER/red5proterraform.service /lib/systemd/system/
+    chmod +x $TERRA_FOLDER/red5terra.sh $TERRA_FOLDER/terraform
+    chmod 644 /lib/systemd/system/red5proterraform.service
+    systemctl daemon-reload
+    systemctl enable red5proterraform.service
+}
+
+config_terraform_service(){
+    log_i "TERRAFORM SERVICE CONFIGURATION"
+
+    local TERRA_API_KEY_pattern='api.accessToken=.*'
+    local TERRA_API_KEY_new="api.accessToken=${TERRA_API_KEY}"
+    
+    local terra_parallelism_pattern='terra.parallelism=.*'
+    local terra_parallelism_new="terra.parallelism=${TERRA_PARALLELISM}"
+
+    local do_api_token='.*cloud.do_api_token=.*'
+    local do_api_token_new="#cloud.do_api_token="
+
+    local do_ssh_key_name='.*cloud.do_ssh_key_name=.*'
+    local do_ssh_key_name_new="#cloud.do_ssh_key_name="
+
+    local gcp_project_id='.*cloud.gcp_project_id=.*'
+    local gcp_project_id_new="cloud.gcp_project_id=${GCP_PROJECT_ID}"
+
+    local gcp_vpc_name='.*cloud.gcp_vpc_name=.*'
+    local gcp_vpc_name_new="cloud.gcp_vpc_name=${GCP_VPC_NAME}"
+
+    local gcp_node_disk_type='.*cloud.gcp_node_boot_disk_type=.*'
+    local gcp_node_disk_type_new="cloud.gcp_node_boot_disk_type=${GCP_NODE_DISK_TYPE}"
+
+    local gcp_node_network_tag='.*cloud.gcp_node_network_tag=.*'
+    local gcp_node_network_tag_new="cloud.gcp_node_network_tag=${GCP_NODE_NETWORK_TAG}"
+    
+    local db_host_pattern='config.dbHost=.*'
+    local db_host_new="config.dbHost=${DB_HOST}"
+    
+    local db_port_pattern='config.dbPort=.*'
+    local db_port_new="config.dbPort=${DB_PORT}"
+    
+    local db_user_pattern='config.dbUser=.*'
+    local db_user_new="config.dbUser=${DB_USER}"
+    
+    local db_password_pattern='config.dbPass=.*'
+    local db_password_new="config.dbPass=${DB_PASSWORD}"
+    
+    sed -i -e "s|$gcp_node_disk_type|$gcp_node_disk_type_new|" -e "s|$gcp_node_network_tag|$gcp_node_network_tag_new|" -e "s|$gcp_project_id|$gcp_project_id_new|" -e "s|$gcp_vpc_name|$gcp_vpc_name_new|" -e "s|$TERRA_API_KEY_pattern|$TERRA_API_KEY_new|" -e "s|$terra_parallelism_pattern|$terra_parallelism_new|" -e "s|$do_api_token|$do_api_token_new|" -e "s|$do_ssh_key_name|$do_ssh_key_name_new|" -e "s|$db_host_pattern|$db_host_new|" -e "s|$db_port_pattern|$db_port_new|" -e "s|$db_user_pattern|$db_user_new|" -e "s|$db_password_pattern|$db_password_new|" "$TERRA_FOLDER/application.properties"
+}
+
+start_terraform_service(){
+    log_i "STARTING TERRAFORM SERVICE"
+    systemctl restart red5proterraform.service
+    
+    if [ "0" -eq $? ]; then
+        log_i "TERRAFORM SERVICE started!"
+    else
+        log_e "TERRAFORM SERVICE didn't start!!!"
+        exit 1
+    fi
+    
+}
+
+install_gcloud_cli(){
+    log_i "Installing gcloud CLI"
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+
+    log_i "Adding gcloud CLI distribution"
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+    log_i "Updating and instaling CLI package"
+    PACKAGES=(google-cloud-cli)
+    install_pkg
+
+}
+
+if [[ "$TF_SVC_ENABLE" == true ]]; then
+    log_i "TF_SVC_ENABLE is set to true, Installing Red5 Pro Terraform Service..."
+    export LC_ALL="en_US.UTF-8"
+    export LC_CTYPE="en_US.UTF-8"
+
+    check_terraform_variables
+    install_pkg
+    install_gcloud_cli
+    install_terraform_service
+    config_terraform_service
+    start_terraform_service
+else
+    log_i "SKIP Red5 Pro Terraform Service installation."
+fi

--- a/variable.tf
+++ b/variable.tf
@@ -333,8 +333,14 @@ variable "red5pro_cluster_key" {
   default     = ""
 }
 
-variable "path_to_google_cloud_controller" {
-  description = "Path to the google cloud controller file, absolute path or relative path. https://account.red5pro.com/downloads. Example: /home/ubuntu/google-cloud-controller-0.0.0.jar"
+variable "path_to_terraform_cloud_controller" {
+  description = "Path to the terraform cloud controller file, absolute path or relative path. https://account.red5pro.com/downloads. Example: /home/ubuntu/terraform-cloud-controller-0.0.0.jar"
+  type        = string
+  default     = ""
+}
+
+variable "path_to_terraform_service_build" {
+  description = "Path to the Terraform Service build zip file, absolute path or relative path. https://account.red5pro.com/downloads. Example: /home/ubuntu/terraform-gcp-red5pro/terraform-service-0.0.0.zip"
   type        = string
   default     = ""
 }
@@ -854,4 +860,46 @@ variable "node_group_relays_capacity" {
   description = "Connections capacity for Relays"
   type        = number
   default     = 30
+}
+
+# Red5 Pro Terraform Service properties
+variable "terraform_service_instance_create" {
+  description = "Create a dedicated GCP instance for Red5 pro Terraform Service "
+  type        = bool
+  default     = false
+}
+variable "terraform_service_api_key" {
+  description = "API key for Teraform Service to autherize the APIs"
+  type        = string
+  default     = ""
+}
+variable "terraform_service_parallelism" {
+  description = "Number of Terraform concurrent operations and used for non-standard rate limiting"
+  type        = string
+  default     = "20"
+}
+variable "terraform_service_instance_type" {
+  description = "Red5 Pro Stream Manager server instance type"
+  type        = string
+  default     = "n2-standard-2"
+}
+variable "terraform_service_boot_disk_type" {
+  description = "Boot disk type for Terraform server. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`"
+  type        = string
+  default     = ""
+}
+variable "red5_terraform_service_firewall_ports" {
+  description = "The required port open for the Terraform server in Google cloud firewall"
+  type        = list(string)
+  default     = ["8083", "22"]
+}
+variable "gcp_node_network_tag" {
+  description = "Specify Node Network tag which will be used by Terraform service while creating Node. Default value is null"
+  type        = string
+  default     = "null"
+}
+variable "gcp_node_boot_disk_type" {
+  description = "Boot disk type for Nodes in Terraform Service. Possible values are `pd-ssd`, `pd-standard`, `pd-balanced`"
+  type        = string
+  default     = ""
 }

--- a/variable.tf
+++ b/variable.tf
@@ -903,3 +903,18 @@ variable "gcp_node_boot_disk_type" {
   type        = string
   default     = ""
 }
+variable "stream_manager_network_tag" {
+  description = "Specify the Network Tag for Stream Manager to be used by the Virtual Network firewall"
+  type        = string
+  default     = ""
+}
+variable "terraform_service_network_tag" {
+  description = "Specify the Network Tag for Terraform Service instance to be used by the Virtual Network firewall"
+  type        = string
+  default     = ""
+}
+variable "single_server_network_tag" {
+  description = "Specify the Network Tag for Red5 Single Server instance to be used by the Virtual Network firewall"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- Upgraded GCP Terraform Module to use `Terraform Service` instead of `Google Cloud Controller`.
- Resolved issue with Deprecated version for MySQL DB
- Updated README.md